### PR TITLE
feat: upgrade DataFusion v51 >> v53, pyo3 0.26 >> 0.28, arrow 57 >> 58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,15 +69,16 @@ checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "apache-avro"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a033b4ced7c585199fb78ef50fca7fe2f444369ec48080c5fd072efa1a03cc7"
+checksum = "36fa98bc79671c7981272d91a8753a928ff6a1cd8e4f20a44c45bd5d313840bf"
 dependencies = [
  "bigdecimal",
  "bon",
- "bzip2 0.6.1",
+ "bzip2",
  "crc32fast",
  "digest",
+ "liblzma",
  "log",
  "miniz_oxide",
  "num-bigint",
@@ -92,7 +93,6 @@ dependencies = [
  "strum_macros 0.27.2",
  "thiserror",
  "uuid",
- "xz2",
  "zstd",
 ]
 
@@ -110,9 +110,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb372a7cbcac02a35d3fb7b3fc1f969ec078e871f9bb899bf00a2e1809bec8a3"
+checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f377dcd19e440174596d83deb49cd724886d91060c07fec4f67014ef9d54049"
+checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eaff85a44e9fa914660fb0d0bb00b79c4a3d888b5334adb3ea4330c84f002"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2819d893750cb3380ab31ebdc8c68874dd4429f90fd09180f3c93538bd21626"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
 dependencies = [
  "bytes",
  "half",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d131abb183f80c450d4591dc784f8d7750c50c6e2bc3fcaad148afc8361271"
+checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275877a0e5e7e7c76954669366c2aa1a829e340ab1f612e647507860906fb6b"
+checksum = "ca025bd0f38eeecb57c2153c0123b960494138e6a957bbda10da2b25415209fe"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05738f3d42cb922b9096f7786f606fcb8669260c2640df8490533bb2fa38c9d3"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d09446e8076c4b3f235603d9ea7c5494e73d441b01cd61fb33d7254c11964b3"
+checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "371ffd66fa77f71d7628c63f209c9ca5341081051aa32f9c8020feb0def787c0"
+checksum = "6ead0914e4861a531be48fe05858265cf854a4880b9ed12618b1d08cba9bebc8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc94fc7adec5d1ba9e8cd1b1e8d6f72423b33fe978bf1f46d970fafab787521"
+checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-pyarrow"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd810e3997bae72f58cda57231ccb0a2fda07911ca1b0a5718cbf9379abb297"
+checksum = "e63351dc11981a316c828a6032a5021345bba882f68bc4a36c36825a50725089"
 dependencies = [
  "arrow-array",
  "arrow-data",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169676f317157dc079cc5def6354d16db63d8861d61046d2f3883268ced6f99f"
+checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27609cd7dd45f006abae27995c2729ef6f4b9361cde1ddd019dc31a5aa017e0"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
 dependencies = [
  "bitflags",
  "serde_core",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae980d021879ea119dd6e2a13912d81e64abed372d53163e804dfe84639d8010"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf35e8ef49dcf0c5f6d175edee6b8af7b45611805333129c541a8b89a0fc0534"
+checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -347,19 +347,14 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.19"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
- "bzip2 0.5.2",
- "flate2",
- "futures-core",
- "memchr",
+ "compression-codecs",
+ "compression-core",
  "pin-project-lite",
  "tokio",
- "xz2",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -832,9 +827,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"
@@ -848,30 +843,11 @@ dependencies = [
 
 [[package]]
 name = "bzip2"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
-dependencies = [
- "bzip2-sys",
-]
-
-[[package]]
-name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[package]]
@@ -898,10 +874,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.42"
+name = "chacha20"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -911,23 +898,12 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efdce149c370f133a071ca8ef6ea340b7b88748ab0810097a9e2976eaa34b4f3"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "chrono-tz-build",
  "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f10f8c9340e31fc120ff885fcdb54a0b48e474bbd77cab557f0c30a3e569402"
-dependencies = [
- "parse-zoneinfo",
- "phf_codegen",
 ]
 
 [[package]]
@@ -940,6 +916,27 @@ dependencies = [
  "strum_macros 0.26.4",
  "unicode-width",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "bzip2",
+ "compression-core",
+ "flate2",
+ "liblzma",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "const-random"
@@ -998,6 +995,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1105,15 +1111,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba7cb113e9c0bedf9e9765926031e132fa05a1b09ba6e93a6d1a4d7044457b8"
+checksum = "de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16"
 dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
  "bytes",
- "bzip2 0.6.1",
+ "bzip2",
  "chrono",
  "datafusion-catalog",
  "datafusion-catalog-listing",
@@ -1144,27 +1150,26 @@ dependencies = [
  "flate2",
  "futures",
  "itertools",
+ "liblzma",
  "log",
  "object_store",
  "parking_lot",
  "parquet",
  "rand 0.9.2",
  "regex",
- "rstest",
  "sqlparser",
  "tempfile",
  "tokio",
  "url",
  "uuid",
- "xz2",
  "zstd",
 ]
 
 [[package]]
 name = "datafusion-catalog"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a3a799f914a59b1ea343906a0486f17061f39509af74e874a866428951130d"
+checksum = "be893b73a13671f310ffcc8da2c546b81efcc54c22e0382c0a28aa3537017137"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1187,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db1b113c80d7a0febcd901476a57aef378e717c54517a163ed51417d87621b0"
+checksum = "830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1206,14 +1211,13 @@ dependencies = [
  "itertools",
  "log",
  "object_store",
- "tokio",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c10f7659e96127d25e8366be7c8be4109595d6a2c3eac70421f380a7006a1b0"
+checksum = "0d7663f3af955292f8004e74bcaf8f7ea3d66cc38438749615bb84815b61a293"
 dependencies = [
  "ahash",
  "apache-avro",
@@ -1221,14 +1225,14 @@ dependencies = [
  "arrow-ipc",
  "chrono",
  "half",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "indexmap",
+ "itertools",
  "libc",
  "log",
  "object_store",
  "parquet",
  "paste",
- "pyo3",
  "recursive",
  "sqlparser",
  "tokio",
@@ -1237,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92065bbc6532c6651e2f7dd30b55cba0c7a14f860c7e1d15f165c41a1868d95"
+checksum = "5f590205c7e32fe1fea48dd53ffb406e56ae0e7a062213a3ac848db8771641bd"
 dependencies = [
  "futures",
  "log",
@@ -1248,15 +1252,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde13794244bc7581cd82f6fff217068ed79cdc344cafe4ab2c3a1c3510b38d6"
+checksum = "fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79"
 dependencies = [
  "arrow",
  "async-compression",
  "async-trait",
  "bytes",
- "bzip2 0.6.1",
+ "bzip2",
  "chrono",
  "datafusion-common",
  "datafusion-common-runtime",
@@ -1271,21 +1275,21 @@ dependencies = [
  "futures",
  "glob",
  "itertools",
+ "liblzma",
  "log",
  "object_store",
  "rand 0.9.2",
  "tokio",
  "tokio-util",
  "url",
- "xz2",
  "zstd",
 ]
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804fa9b4ecf3157982021770617200ef7c1b2979d57bec9044748314775a9aea"
+checksum = "331ebae7055dc108f9b54994b93dff91f3a17445539efe5b74e89264f7b36e15"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1307,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-avro"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388ed8be535f562cc655b9c3d22edbfb0f1a50a25c242647a98b6d92a75b55a1"
+checksum = "49dda81c79b6ba57b1853a9158abc66eb85a3aa1cede0c517dabec6d8a4ed3aa"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -1327,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a1641a40b259bab38131c5e6f48fac0717bedb7dc93690e604142a849e0568"
+checksum = "9e0d475088325e2986876aa27bb30d0574f72a22955a527d202f454681d55c5c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1350,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adeacdb00c1d37271176f8fb6a1d8ce096baba16ea7a4b2671840c5c9c64fe85"
+checksum = "ea1520d81f31770f3ad6ee98b391e75e87a68a5bb90de70064ace5e0a7182fe8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1367,14 +1371,16 @@ dependencies = [
  "datafusion-session",
  "futures",
  "object_store",
+ "serde_json",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d0b60ffd66f28bfb026565d62b0a6cbc416da09814766a3797bba7d85a3cd9"
+checksum = "95be805d0742ab129720f4c51ad9242cd872599cdb076098b03f061fcdc7f946"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1402,21 +1408,24 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b99e13947667b36ad713549237362afb054b2d8f8cc447751e23ec61202db07"
+checksum = "5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a"
 
 [[package]]
 name = "datafusion-execution"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63695643190679037bc946ad46a263b62016931547bf119859c511f7ff2f5178"
+checksum = "9437d3cd5d363f9319f8122182d4d233427de79c7eb748f23054c9aaa0fdd8df"
 dependencies = [
  "arrow",
+ "arrow-buffer",
  "async-trait",
+ "chrono",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-physical-expr-common",
  "futures",
  "log",
  "object_store",
@@ -1428,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a4787cbf5feb1ab351f789063398f67654a6df75c4d37d7f637dc96f951a91"
+checksum = "67164333342b86521d6d93fa54081ee39839894fb10f7a700c099af96d7552cf"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1451,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce2fb1b8c15c9ac45b0863c30b268c69dc9ee7a1ee13ecf5d067738338173dc"
+checksum = "ab05fdd00e05d5a6ee362882546d29d6d3df43a6c55355164a7fbee12d163bc9"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1464,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794a9db7f7b96b3346fc007ff25e994f09b8f0511b4cf7dff651fadfe3ebb28f"
+checksum = "04fb863482d987cf938db2079e07ab0d3bb64595f28907a6c2f8671ad71cca7e"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1474,6 +1483,7 @@ dependencies = [
  "blake2",
  "blake3",
  "chrono",
+ "chrono-tz",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -1484,6 +1494,7 @@ dependencies = [
  "itertools",
  "log",
  "md-5",
+ "memchr",
  "num-traits",
  "rand 0.9.2",
  "regex",
@@ -1494,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c25210520a9dcf9c2b2cbbce31ebd4131ef5af7fc60ee92b266dc7d159cb305"
+checksum = "829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6"
 dependencies = [
  "ahash",
  "arrow",
@@ -1510,14 +1521,15 @@ dependencies = [
  "datafusion-physical-expr-common",
  "half",
  "log",
+ "num-traits",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f4a66f3b87300bb70f4124b55434d2ae3fe80455f3574701d0348da040b55d"
+checksum = "08af79cc3d2aa874a362fb97decfcbd73d687190cb096f16a6c85a7780cce311"
 dependencies = [
  "ahash",
  "arrow",
@@ -1528,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5c06eed03918dc7fe7a9f082a284050f0e9ecf95d72f57712d1496da03b8c4"
+checksum = "465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1544,16 +1556,18 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-macros",
  "datafusion-physical-expr-common",
+ "hashbrown 0.16.1",
  "itertools",
+ "itoa",
  "log",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-table"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4fed1d71738fbe22e2712d71396db04c25de4111f1ec252b8f4c6d3b25d7f5"
+checksum = "6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1567,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d92206aa5ae21892f1552b4d61758a862a70956e6fd7a95cb85db1de74bc6d1"
+checksum = "ca7baec14f866729012efb89011a6973f3a346dc8090c567bfcd328deff551c1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1585,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ae9bcc39800820d53a22d758b3b8726ff84a5a3e24cecef04ef4e5fdf1c7cc"
+checksum = "159228c3280d342658466bb556dc24de30047fe1d7e559dc5d16ccc5324166f9"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1595,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1063ad4c9e094b3f798acee16d9a47bd7372d9699be2de21b05c3bd3f34ab848"
+checksum = "e5427e5da5edca4d21ea1c7f50e1c9421775fe33d7d5726e5641a833566e7578"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -1606,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35f9ec5d08b87fd1893a30c2929f2559c2f9806ca072d8fefca5009dc0f06a"
+checksum = "89099eefcd5b223ec685c36a41d35c69239236310d71d339f2af0fa4383f3f46"
 dependencies = [
  "arrow",
  "chrono",
@@ -1626,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30cc8012e9eedcb48bbe112c6eff4ae5ed19cf3003cb0f505662e88b7014c5d"
+checksum = "0f222df5195d605d79098ef37bdd5323bff0131c9d877a24da6ec98dfca9fe36"
 dependencies = [
  "ahash",
  "arrow",
@@ -1638,19 +1652,21 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "itertools",
  "parking_lot",
  "paste",
  "petgraph",
+ "recursive",
+ "tokio",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9ff2dbd476221b1f67337699eff432781c4e6e1713d2aefdaa517dfbf79768"
+checksum = "40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1663,23 +1679,26 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90da43e1ec550b172f34c87ec68161986ced70fd05c8d2a2add66eef9c276f03"
+checksum = "eacbcc4cfd502558184ed58fa3c72e775ec65bf077eef5fd2b3453db676f893c"
 dependencies = [
  "ahash",
  "arrow",
+ "chrono",
  "datafusion-common",
  "datafusion-expr-common",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
+ "indexmap",
  "itertools",
+ "parking_lot",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9804f799acd7daef3be7aaffe77c0033768ed8fdbf5fb82fc4c5f2e6bc14e6"
+checksum = "d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1696,30 +1715,31 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0acf0ad6b6924c6b1aa7d213b181e012e2d3ec0a64ff5b10ee6282ab0f8532ac"
+checksum = "463c88ad6f1ecab1810f4c9f046898bee035b370137eb79b2b2db925e270631d"
 dependencies = [
  "ahash",
  "arrow",
  "arrow-ord",
  "arrow-schema",
  "async-trait",
- "chrono",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-functions",
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "futures",
  "half",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "itertools",
  "log",
+ "num-traits",
  "parking_lot",
  "pin-project-lite",
  "tokio",
@@ -1727,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2c2498a1f134a9e11a9f5ed202a2a7d7e9774bd9249295593053ea3be999db"
+checksum = "2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1744,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f96eebd17555386f459037c65ab73aae8df09f464524c709d6a3134ad4f4776"
+checksum = "ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -1758,15 +1778,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "51.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc195fe60634b2c6ccfd131b487de46dc30eccae8a3c35a13f136e7f440414f"
+checksum = "12d9e9f16a1692a11c94bcc418191fa15fd2b4d72a0c1a0c607db93c0b84dd81"
 dependencies = [
  "arrow",
  "bigdecimal",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-functions-nested",
  "indexmap",
  "log",
  "recursive",
@@ -1851,13 +1872,13 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "libz-rs-sys",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1871,6 +1892,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1953,12 +1980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,9 +2029,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.2.0",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2074,10 +2109,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2085,7 +2116,7 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2093,6 +2124,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -2430,6 +2466,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,19 +2500,15 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
-
-[[package]]
-name = "indoc"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "integer-encoding"
@@ -2517,6 +2555,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lexical-core"
@@ -2590,24 +2634,35 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "liblzma"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a60851d15cd8c5346eca4ab8babff585be2ae4bc8097c067291d3ffe2add3b6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
-
-[[package]]
-name = "libz-rs-sys"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15413ef615ad868d4d65dce091cb233b229419c7c0c4bcaa746c0901c49ff39c"
-dependencies = [
- "zlib-rs",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2633,28 +2688,17 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 dependencies = [
  "twox-hash",
-]
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -2669,18 +2713,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -2700,13 +2735,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2756,16 +2791,18 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.4"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http 1.3.1",
  "http-body-util",
  "humantime",
@@ -2775,10 +2812,10 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.2",
+ "rand 0.10.0",
  "reqwest",
  "ring",
- "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2843,14 +2880,13 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "57.1.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be3e4f6d320dd92bfa7d612e265d7d08bba0a240bab86af3425e1d255a511d89"
+checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
 dependencies = [
  "ahash",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
  "arrow-data",
  "arrow-ipc",
  "arrow-schema",
@@ -2879,15 +2915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2913,38 +2940,18 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
  "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -2999,15 +3006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,9 +3016,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3028,9 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -3050,28 +3048,26 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ee6d4cb3e8d5b925f5cdb38da183e0ff18122eb2048d4041c9e7034d026e23"
+checksum = "9e7364a95bf00e8377bbf9b0f09d7ff9715a29d8fcf93b47d1a967363b973178"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "once_cell",
  "pin-project-lite",
  "pyo3",
@@ -3080,18 +3076,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3099,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3111,9 +3107,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3130,9 +3126,9 @@ checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
  "serde",
@@ -3194,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3208,13 +3204,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core 0.6.4",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -3224,6 +3217,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3238,18 +3242,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "rand_core"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "recursive"
@@ -3305,21 +3309,15 @@ dependencies = [
 
 [[package]]
 name = "regex-lite"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
-
-[[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -3379,35 +3377,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rstest"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn",
- "unicode-ident",
 ]
 
 [[package]]
@@ -3642,11 +3611,12 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.17"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3701,7 +3671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3771,19 +3741,19 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "sqlparser"
-version = "0.59.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
+checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
 dependencies = [
  "log",
  "recursive",
@@ -3792,9 +3762,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3877,9 +3847,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4022,25 +3992,25 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4068,6 +4038,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4078,36 +4060,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.23.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
-dependencies = [
- "winnow",
 ]
 
 [[package]]
@@ -4205,10 +4157,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
-name = "unindent"
-version = "0.2.4"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -4248,11 +4200,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4302,6 +4254,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -4376,6 +4346,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4386,6 +4378,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.2",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -4658,12 +4662,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
-name = "winnow"
-version = "0.7.14"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "memchr",
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4673,6 +4688,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
@@ -4695,7 +4778,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xorq-datafusion"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -4714,15 +4797,6 @@ dependencies = [
  "pyo3-async-runtimes",
  "tokio",
  "url",
-]
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
 ]
 
 [[package]]
@@ -4840,9 +4914,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f936044d677be1a1168fae1d03b583a285a5dd9d8cbf7b24c23aa1fc775235"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xorq-datafusion"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,20 +9,20 @@ name = "xorq_datafusion"
 crate-type = ["cdylib"]
 
 [dependencies]
-tokio = { version = "1.47", features = ["macros", "rt", "rt-multi-thread", "sync"] }
-pyo3 = { version = "0.26", features = ["extension-module", "abi3", "abi3-py38"] }
-pyo3-async-runtimes = { version = "0.26", features = ["tokio-runtime"]}
-datafusion =  { version = "51.0", features = ["pyarrow", "avro"]}
-datafusion-common = { version = "51.0", features = ["pyarrow"] }
-datafusion-expr = "51.0"
-prost = "=0.14.1"
-datafusion-optimizer = "51.0"
-datafusion-sql = "51.0"
-futures = "=0.3.31"
+tokio = { version = "1.50", features = ["macros", "rt", "rt-multi-thread", "sync"] }
+pyo3 = { version = "0.28", features = ["extension-module", "abi3", "abi3-py38"] }
+pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"]}
+datafusion =  { version = "53", features = ["avro", "unicode_expressions"]}
+datafusion-common = { version = "53" }
+datafusion-expr = "53"
+prost = "0.14.3"
+datafusion-optimizer = "53"
+datafusion-sql = "53"
+futures = "0.3"
 async-trait = "=0.1.89"
-arrow = "57"
-arrow-ord = "57"
+arrow = { version = "58", features = ["pyarrow"] }
+arrow-ord = "58"
 aws-config = "=0.101.0"
 aws-credential-types = "=0.101.0"
-object_store = { version = "=0.12.4", features = ["aws", "gcp", "http"] }
+object_store = { version = "0.13.1", features = ["aws", "gcp", "http"] }
 url = "2.5.7"

--- a/python/tests/test_context.py
+++ b/python/tests/test_context.py
@@ -34,7 +34,6 @@ def test_register_record_batches(ctx):
 
 
 def test_register_record_batch_reader(ctx):
-    # create a RecordBatch and register it as memtable
     batch = pa.RecordBatch.from_arrays(
         [pa.array([1, 2, 3]), pa.array([4, 5, 6])],
         names=["a", "b"],
@@ -50,6 +49,112 @@ def test_register_record_batch_reader(ctx):
 
     assert result[0].column(0) == pa.array([5, 7, 9])
     assert result[0].column(1) == pa.array([-3, -3, -3])
+
+
+def test_register_record_batch_reader_replay(ctx):
+    """A pa.Table supports multiple __arrow_c_stream__() calls, so the same
+    registered table should be scannable across successive queries."""
+    table = pa.table({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    ctx.register_record_batch_reader("t", table)
+
+    expected_sum = pa.array([5, 7, 9])
+    expected_diff = pa.array([-3, -3, -3])
+
+    for _ in range(3):
+        result = ctx.sql("SELECT a+b, a-b FROM t").collect()
+        assert result[0].column(0) == expected_sum
+        assert result[0].column(1) == expected_diff
+
+
+def test_register_record_batch_reader_lazy(ctx):
+    """Batches must be fetched on demand.
+
+    With LIMIT 1 against 10 batches of 100 rows each, a lazy implementation
+    stops after reading the first batch.  An eager implementation would read
+    all 10 batches before returning any results.
+    """
+    num_batches = 10
+    rows_per_batch = 100
+    schema = pa.schema([("x", pa.int64())])
+    batches_fetched = []
+
+    class TrackingReader:
+        """Arrow-stream-compatible object that records each batch as it is pulled."""
+
+        @property
+        def schema(self):
+            return schema
+
+        def __arrow_c_stream__(self, requested_schema=None):
+            def gen():
+                for i in range(num_batches):
+                    batches_fetched.append(i)
+                    yield pa.record_batch(
+                        {"x": list(range(rows_per_batch))}, schema=schema
+                    )
+
+            return pa.RecordBatchReader.from_batches(schema, gen()).__arrow_c_stream__(
+                requested_schema
+            )
+
+    ctx.register_record_batch_reader("tracking_t", TrackingReader())
+
+    result = ctx.sql("SELECT x FROM tracking_t LIMIT 1").collect()
+
+    assert sum(len(b) for b in result) == 1
+    # Laziness: LIMIT 1 with 100 rows/batch means only the first batch is needed.
+    # Allow for one extra batch in case a prefetch is in flight when the limit fires.
+    assert len(batches_fetched) < num_batches, (
+        f"Expected lazy reading to stop early, "
+        f"but {len(batches_fetched)}/{num_batches} batches were fetched"
+    )
+
+
+def test_register_record_batch_reader_batchcorder_self_join(ctx):
+    """StreamCache wraps a single-use RecordBatchReader so it becomes replayable.
+
+    A self-join requires two independent scans of the same registered table.
+    Without replay capability the second scan would return empty results or
+    raise an error.  batchcorder.StreamCache + .cast() gives us a
+    CastingStreamCache whose __arrow_c_stream__ produces a fresh reader on
+    every call, satisfying DataFusion's multi-scan requirement.
+    """
+    batchcorder = pytest.importorskip("batchcorder")
+
+    schema = pa.schema([("id", pa.int64()), ("val", pa.float64())])
+    batches = [
+        pa.record_batch({"id": [1, 2, 3], "val": [0.5, 1.0, 1.5]}, schema=schema),
+        pa.record_batch({"id": [4, 5], "val": [2.0, 2.5]}, schema=schema),
+    ]
+    # pa.RecordBatchReader is single-use; StreamCache makes it replayable.
+    reader = pa.RecordBatchReader.from_batches(schema, batches)
+    cache = batchcorder.StreamCache(reader)
+    # CastingStreamCache.__arrow_c_stream__ returns a fresh reader each call.
+    replayable = cache.cast(schema)
+
+    ctx.register_record_batch_reader("t", replayable)
+
+    # Self-join requires two scans; filter is pushed into the left side only.
+    result = ctx.sql(
+        """
+        SELECT l.id, l.val, r.val AS r_val
+          FROM t AS l
+          JOIN t AS r ON l.id = r.id
+         WHERE l.val > 0.5
+         ORDER BY l.id
+        """
+    ).collect()
+
+    assert len(result) == 1
+    combined = result[0]
+    assert combined.column("id") == pa.array([2, 3, 4, 5], type=pa.int64())
+    assert combined.column("val") == pa.array([1.0, 1.5, 2.0, 2.5], type=pa.float64())
+    assert combined.column("r_val") == pa.array([1.0, 1.5, 2.0, 2.5], type=pa.float64())
+
+    # Ingest all remaining batches and confirm the cache is fully populated.
+    # cache.ingest_all()
+    assert cache.upstream_exhausted
 
 
 def test_register_table(ctx, data_dir):
@@ -202,6 +307,73 @@ def test_get_object_metadata_local_filesystem(ctx, data_dir):
     metadata = ctx.get_object_metadata(str(url.resolve()), "parquet")
 
     assert isinstance(metadata, dict)
+
+
+def test_large_batting_self_join_limit(ctx):
+    """Self-join on a 16 000-row batting-like table with LIMIT 15 returns bounded results.
+
+    Mirrors the batting self-join pattern from test_into_backend_datafusion but uses
+    in-memory data so no external backend is required.
+    """
+
+    batchcorder = pytest.importorskip("batchcorder")
+
+    n_rows = 16_000
+    n_players = 1_000
+
+    def cycle(seq, n):
+        return [seq[i % len(seq)] for i in range(n)]
+
+    table = pa.table(
+        {
+            "playerID": pa.array([f"player{i % n_players:04d}" for i in range(n_rows)]),
+            "yearID": pa.array(cycle(list(range(1990, 2020)), n_rows), type=pa.int64()),
+            "stint": pa.array([i % 3 + 1 for i in range(n_rows)], type=pa.int64()),
+            "teamID": pa.array([f"TM{i % 30:02d}" for i in range(n_rows)]),
+            "lgID": pa.array(["AL" if i % 2 == 0 else "NL" for i in range(n_rows)]),
+            "G": pa.array([i % 162 + 1 for i in range(n_rows)], type=pa.int64()),
+            "AB": pa.array([i % 600 for i in range(n_rows)], type=pa.int64()),
+            "R": pa.array([i % 100 for i in range(n_rows)], type=pa.int64()),
+            "H": pa.array([i % 200 for i in range(n_rows)], type=pa.int64()),
+            "X2B": pa.array([i % 50 for i in range(n_rows)], type=pa.int64()),
+            "X3B": pa.array([i % 20 for i in range(n_rows)], type=pa.int64()),
+            "HR": pa.array([i % 50 for i in range(n_rows)], type=pa.int64()),
+            "RBI": pa.array([i % 130 for i in range(n_rows)], type=pa.int64()),
+            "SB": pa.array([i % 50 for i in range(n_rows)], type=pa.int64()),
+            "CS": pa.array([i % 20 for i in range(n_rows)], type=pa.int64()),
+            "BB": pa.array([i % 100 for i in range(n_rows)], type=pa.int64()),
+            "SO": pa.array([i % 200 for i in range(n_rows)], type=pa.int64()),
+            "IBB": pa.array([i % 30 for i in range(n_rows)], type=pa.int64()),
+            "HBP": pa.array([i % 20 for i in range(n_rows)], type=pa.int64()),
+            "SH": pa.array([i % 20 for i in range(n_rows)], type=pa.int64()),
+            "SF": pa.array([i % 10 for i in range(n_rows)], type=pa.int64()),
+            "GIDP": pa.array([i % 30 for i in range(n_rows)], type=pa.int64()),
+        }
+    )
+
+    ctx.register_record_batch_reader(
+        "ls_batting", batchcorder.StreamCache(table.to_reader(max_chunksize=1000))
+    )
+
+    result = ctx.sql(
+        """
+        SELECT
+          t4.player_id,
+          t4.year_id
+        FROM (
+          SELECT
+            t1."playerID" AS player_id,
+            t2."yearID" AS year_id
+          FROM ls_batting AS t1
+          INNER JOIN ls_batting AS t2
+            ON t1."playerID" = t2."playerID"
+          LIMIT 15
+        ) AS t4
+        """
+    ).collect()
+
+    total_rows = sum(len(b) for b in result)
+    assert 0 < total_rows <= 15
 
 
 def test_get_object_metadata_https(ctx):

--- a/src/common/data_type.rs
+++ b/src/common/data_type.rs
@@ -37,7 +37,13 @@ impl From<PyScalarValue> for ScalarValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "RexType", module = "datafusion.common")]
+#[pyclass(
+    from_py_object,
+    eq,
+    eq_int,
+    name = "RexType",
+    module = "datafusion.common"
+)]
 pub enum RexType {
     Alias,
     Literal,
@@ -57,7 +63,12 @@ pub enum RexType {
 /// to map those types and provide a simple place for developers
 /// to map types from one system to another.
 #[derive(Debug, Clone)]
-#[pyclass(name = "DataTypeMap", module = "datafusion.common", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "DataTypeMap",
+    module = "datafusion.common",
+    subclass
+)]
 pub struct DataTypeMap {
     #[pyo3(get, set)]
     pub arrow_type: PyDataType,
@@ -623,7 +634,7 @@ impl DataTypeMap {
 /// Since `DataType` exists in another package we cannot make that happen here so we wrap
 /// `DataType` as `PyDataType` This exists solely to satisfy those constraints.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(name = "DataType", module = "datafusion.common")]
+#[pyclass(from_py_object, name = "DataType", module = "datafusion.common")]
 pub struct PyDataType {
     pub data_type: DataType,
 }
@@ -708,7 +719,13 @@ impl From<DataType> for PyDataType {
 
 /// Represents the possible Python types that can be mapped to the SQL types
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "PythonType", module = "datafusion.common")]
+#[pyclass(
+    from_py_object,
+    eq,
+    eq_int,
+    name = "PythonType",
+    module = "datafusion.common"
+)]
 pub enum PythonType {
     Array,
     Bool,
@@ -728,7 +745,13 @@ pub enum PythonType {
 #[allow(non_camel_case_types)]
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[pyclass(eq, eq_int, name = "SqlType", module = "datafusion.common")]
+#[pyclass(
+    from_py_object,
+    eq,
+    eq_int,
+    name = "SqlType",
+    module = "datafusion.common"
+)]
 pub enum SqlType {
     ANY,
     ARRAY,

--- a/src/common/df_schema.rs
+++ b/src/common/df_schema.rs
@@ -21,7 +21,12 @@ use datafusion_common::DFSchema;
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "DFSchema", module = "datafusion.common", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "DFSchema",
+    module = "datafusion.common",
+    subclass
+)]
 pub struct PyDFSchema {
     schema: Arc<DFSchema>,
 }

--- a/src/common/function.rs
+++ b/src/common/function.rs
@@ -22,7 +22,12 @@ use pyo3::prelude::*;
 
 use super::data_type::PyDataType;
 
-#[pyclass(name = "SqlFunction", module = "datafusion.common", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "SqlFunction",
+    module = "datafusion.common",
+    subclass
+)]
 #[derive(Debug, Clone)]
 pub struct SqlFunction {
     pub name: String,

--- a/src/common/schema.rs
+++ b/src/common/schema.rs
@@ -25,7 +25,12 @@ use datafusion_expr::utils::split_conjunction;
 
 use super::{data_type::DataTypeMap, function::SqlFunction};
 
-#[pyclass(name = "SqlSchema", module = "datafusion.common", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "SqlSchema",
+    module = "datafusion.common",
+    subclass
+)]
 #[derive(Debug, Clone)]
 pub struct SqlSchema {
     #[pyo3(get, set)]
@@ -38,7 +43,12 @@ pub struct SqlSchema {
     pub functions: Vec<SqlFunction>,
 }
 
-#[pyclass(name = "SqlTable", module = "datafusion.common", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "SqlTable",
+    module = "datafusion.common",
+    subclass
+)]
 #[derive(Debug, Clone)]
 pub struct SqlTable {
     #[pyo3(get, set)]
@@ -82,7 +92,12 @@ impl SqlTable {
     }
 }
 
-#[pyclass(name = "SqlView", module = "datafusion.common", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "SqlView",
+    module = "datafusion.common",
+    subclass
+)]
 #[derive(Debug, Clone)]
 pub struct SqlView {
     #[pyo3(get, set)]
@@ -200,7 +215,12 @@ fn is_supported_push_down_expr(_expr: &Expr) -> bool {
     true
 }
 
-#[pyclass(name = "SqlStatistics", module = "datafusion.common", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "SqlStatistics",
+    module = "datafusion.common",
+    subclass
+)]
 #[derive(Debug, Clone)]
 pub struct SqlStatistics {
     row_count: f64,

--- a/src/context.rs
+++ b/src/context.rs
@@ -15,10 +15,8 @@ use crate::udaf::PyAggregateUDF;
 use crate::udf::PyScalarUDF;
 use crate::udwf::PyWindowUDF;
 use crate::utils::wait_for_future;
-use arrow::array::RecordBatchReader;
 use arrow_ord::sort::SortOptions;
 use datafusion::arrow::datatypes::{DataType, Schema};
-use datafusion::arrow::ffi_stream::ArrowArrayStreamReader;
 use datafusion::arrow::pyarrow::PyArrowType;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::file_format::file_compression_type::FileCompressionType;
@@ -35,7 +33,7 @@ use datafusion_common::config::ConfigFileType;
 use datafusion_common::{exec_err, ScalarValue, TableReference};
 use datafusion_expr::Expr;
 use datafusion_expr::ScalarUDF;
-use object_store::{Error, ObjectMeta, ObjectStore, ObjectStoreScheme};
+use object_store::{Error, GetOptions, ObjectMeta, ObjectStoreScheme};
 use pyo3::exceptions::{PyKeyError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -47,7 +45,7 @@ use std::sync::Arc;
 use tokio::task::JoinSet;
 
 /// Configuration options for a SessionContext
-#[pyclass(name = "SessionConfig", module = "let", subclass)]
+#[pyclass(from_py_object, name = "SessionConfig", module = "let", subclass)]
 #[derive(Clone, Default)]
 pub(crate) struct PySessionConfig {
     pub(crate) config: SessionConfig,
@@ -139,7 +137,7 @@ impl PySessionConfig {
     }
 }
 
-#[pyclass(name = "SessionState", module = "let", subclass)]
+#[pyclass(from_py_object, name = "SessionState", module = "let", subclass)]
 #[derive(Clone)]
 pub(crate) struct PySessionState {
     pub(crate) session_state: SessionState,
@@ -187,7 +185,7 @@ impl PySessionState {
 /// `PySessionContext` is able to plan and execute DataFusion plans.
 /// It has a powerful optimizer, a physical planner for local execution, and a
 /// multithreaded execution engine to perform the execution.
-#[pyclass(name = "SessionContext", module = "let", subclass)]
+#[pyclass(from_py_object, name = "SessionContext", module = "let", subclass)]
 #[derive(Clone)]
 pub(crate) struct PySessionContext {
     pub(crate) ctx: SessionContext,
@@ -202,7 +200,7 @@ impl PySessionContext {
         config: Option<PySessionConfig>,
     ) -> PyResult<Self> {
         let runtime_config = RuntimeEnvBuilder::default();
-        let runtime = Arc::new(runtime_config.build()?);
+        let runtime = Arc::new(runtime_config.build().map_err(from_datafusion_error)?);
         let session_state = match (session_state, config) {
             (Some(s), _) => s.session_state,
             (None, Some(c)) => SessionStateBuilder::new()
@@ -378,7 +376,7 @@ impl PySessionContext {
         partitions: PyArrowType<Vec<Vec<RecordBatch>>>,
     ) -> PyResult<()> {
         let schema = partitions.0[0][0].schema();
-        let table = MemTable::try_new(schema, partitions.0)?;
+        let table = MemTable::try_new(schema, partitions.0).map_err(from_datafusion_error)?;
         self.ctx
             .register_table(name, Arc::new(table))
             .map_err(from_datafusion_error)?;
@@ -391,11 +389,17 @@ impl PySessionContext {
     pub fn register_record_batch_reader(
         &mut self,
         name: &str,
-        reader: PyArrowType<ArrowArrayStreamReader>,
+        reader: Bound<'_, PyAny>,
         sort_order: Option<Vec<PySortExpr>>,
     ) -> PyResult<()> {
-        let reader = reader.0;
-        let schema = reader.schema();
+        // Extract the schema from the Python object's .schema attribute so that we
+        // do not consume the stream here — it will be re-acquired on each execute().
+        let schema: Arc<Schema> = Arc::new(
+            reader
+                .getattr("schema")?
+                .extract::<PyArrowType<Schema>>()?
+                .0,
+        );
 
         let mut ordering = vec![];
         if let Some(exprs) = sort_order {
@@ -421,7 +425,7 @@ impl PySessionContext {
         }
         let ordering_option = LexOrdering::new(ordering);
 
-        let table = PyRecordBatchProvider::new(reader, ordering_option);
+        let table = PyRecordBatchProvider::new(reader.unbind(), schema, ordering_option);
         self.ctx
             .register_table(name, Arc::new(table))
             .map_err(from_datafusion_error)?;
@@ -505,11 +509,13 @@ impl PySessionContext {
     }
 
     fn table_exist(&self, name: &str) -> PyResult<bool> {
-        Ok(self.ctx.table_exist(name)?)
+        self.ctx.table_exist(name).map_err(from_datafusion_error)
     }
 
     fn empty_table(&self) -> PyResult<PyDataFrame> {
-        Ok(PyDataFrame::new(self.ctx.read_empty()?))
+        Ok(PyDataFrame::new(
+            self.ctx.read_empty().map_err(from_datafusion_error)?,
+        ))
     }
 
     fn session_id(&self) -> String {
@@ -552,7 +558,7 @@ impl PySessionContext {
         let location = &path.to_string();
 
         // Parse the location URL to extract the scheme and other components
-        let table_path = ListingTableUrl::parse(location)?;
+        let table_path = ListingTableUrl::parse(location).map_err(from_datafusion_error)?;
 
         // Extract the scheme (e.g., "s3", "gcs") from the parsed URL
         let scheme = table_path.scheme();
@@ -591,7 +597,9 @@ impl PySessionContext {
         }
 
         if let "s3" | "oss" | "cos" | "gs" | "gcs" = scheme {
-            table_options.alter_with_string_hash_map(&storage_options)?;
+            table_options
+                .alter_with_string_hash_map(&storage_options)
+                .map_err(from_datafusion_error)?;
         }
 
         let result = async {
@@ -603,7 +611,10 @@ impl PySessionContext {
                     source: format!("Source: {e}").into(),
                 })?;
             let (_, object_path) = ObjectStoreScheme::parse(url)?;
-            store.head(&object_path).await
+            store
+                .get_opts(&object_path, GetOptions::new().with_head(true))
+                .await
+                .map(|r| r.meta)
         };
 
         let metadata =

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -23,7 +23,7 @@ use pyo3::IntoPyObjectExt;
 /// A PyDataFrame is a representation of a logical plan and an API to compose statements.
 /// Use it to build a plan and `.collect()` to execute the plan and collect the result.
 /// The actual execution of a plan runs natively on Rust and Arrow on a multi-threaded environment.
-#[pyclass(name = "DataFrame", module = "let", subclass)]
+#[pyclass(from_py_object, name = "DataFrame", module = "let", subclass)]
 #[derive(Clone)]
 pub struct PyDataFrame {
     pub df: Arc<DataFrame>,
@@ -42,7 +42,7 @@ impl PyDataFrame {
         if let Ok(key) = key.extract::<PyBackedStr>() {
             // df[col]
             self.select_columns(vec![key])
-        } else if let Ok(tuple) = key.downcast::<PyTuple>() {
+        } else if let Ok(tuple) = key.cast::<PyTuple>() {
             // df[col1, col2, col3]
             let keys = tuple
                 .iter()
@@ -60,7 +60,12 @@ impl PyDataFrame {
     }
 
     fn __repr__(&self, py: Python) -> PyResult<String> {
-        let df = self.df.as_ref().clone().limit(0, Some(10))?;
+        let df = self
+            .df
+            .as_ref()
+            .clone()
+            .limit(0, Some(10))
+            .map_err(from_datafusion_error)?;
         let batches = wait_for_future(py, df.collect()).map_err(from_datafusion_error)?;
         let batches_as_string = pretty::pretty_format_batches(&batches);
         match batches_as_string {
@@ -84,7 +89,12 @@ impl PyDataFrame {
     #[pyo3(signature = (*args))]
     fn select_columns(&self, args: Vec<PyBackedStr>) -> PyResult<Self> {
         let args = args.iter().map(|s| s.as_ref()).collect::<Vec<&str>>();
-        let df = self.df.as_ref().clone().select_columns(&args)?;
+        let df = self
+            .df
+            .as_ref()
+            .clone()
+            .select_columns(&args)
+            .map_err(from_datafusion_error)?;
         Ok(Self::new(df))
     }
 
@@ -95,13 +105,19 @@ impl PyDataFrame {
             .df
             .as_ref()
             .clone()
-            .with_column_renamed(old_name, new_name)?;
+            .with_column_renamed(old_name, new_name)
+            .map_err(from_datafusion_error)?;
         Ok(Self::new(df))
     }
 
     #[pyo3(signature = (count, offset=0))]
     fn limit(&self, count: usize, offset: usize) -> PyResult<Self> {
-        let df = self.df.as_ref().clone().limit(offset, Some(count))?;
+        let df = self
+            .df
+            .as_ref()
+            .clone()
+            .limit(offset, Some(count))
+            .map_err(from_datafusion_error)?;
         Ok(Self::new(df))
     }
 
@@ -138,13 +154,23 @@ impl PyDataFrame {
     /// Print the result, 20 lines by default
     #[pyo3(signature = (num=20))]
     fn show(&self, py: Python, num: usize) -> PyResult<()> {
-        let df = self.df.as_ref().clone().limit(0, Some(num))?;
+        let df = self
+            .df
+            .as_ref()
+            .clone()
+            .limit(0, Some(num))
+            .map_err(from_datafusion_error)?;
         print_dataframe(py, df)
     }
 
     /// Filter out duplicate rows
     fn distinct(&self) -> PyResult<Self> {
-        let df = self.df.as_ref().clone().distinct()?;
+        let df = self
+            .df
+            .as_ref()
+            .clone()
+            .distinct()
+            .map_err(from_datafusion_error)?;
         Ok(Self::new(df))
     }
 
@@ -179,20 +205,30 @@ impl PyDataFrame {
             .map(|s| s.as_ref())
             .collect::<Vec<&str>>();
 
-        let df = self.df.as_ref().clone().join(
-            right.df.as_ref().clone(),
-            join_type,
-            &left_keys,
-            &right_keys,
-            None,
-        )?;
+        let df = self
+            .df
+            .as_ref()
+            .clone()
+            .join(
+                right.df.as_ref().clone(),
+                join_type,
+                &left_keys,
+                &right_keys,
+                None,
+            )
+            .map_err(from_datafusion_error)?;
         Ok(Self::new(df))
     }
 
     /// Print the query plan
     #[pyo3(signature = (verbose=false, analyze=false))]
     fn explain(&self, py: Python, verbose: bool, analyze: bool) -> PyResult<()> {
-        let df = self.df.as_ref().clone().explain(verbose, analyze)?;
+        let df = self
+            .df
+            .as_ref()
+            .clone()
+            .explain(verbose, analyze)
+            .map_err(from_datafusion_error)?;
         print_dataframe(py, df)
     }
 
@@ -202,7 +238,8 @@ impl PyDataFrame {
             .df
             .as_ref()
             .clone()
-            .repartition(Partitioning::RoundRobinBatch(num))?;
+            .repartition(Partitioning::RoundRobinBatch(num))
+            .map_err(from_datafusion_error)?;
         Ok(Self::new(new_df))
     }
 
@@ -214,9 +251,14 @@ impl PyDataFrame {
             self.df
                 .as_ref()
                 .clone()
-                .union_distinct(py_df.df.as_ref().clone())?
+                .union_distinct(py_df.df.as_ref().clone())
+                .map_err(from_datafusion_error)?
         } else {
-            self.df.as_ref().clone().union(py_df.df.as_ref().clone())?
+            self.df
+                .as_ref()
+                .clone()
+                .union(py_df.df.as_ref().clone())
+                .map_err(from_datafusion_error)?
         };
 
         Ok(Self::new(new_df))
@@ -229,7 +271,8 @@ impl PyDataFrame {
             .df
             .as_ref()
             .clone()
-            .union_distinct(py_df.df.as_ref().clone())?;
+            .union_distinct(py_df.df.as_ref().clone())
+            .map_err(from_datafusion_error)?;
         Ok(Self::new(new_df))
     }
 
@@ -239,13 +282,19 @@ impl PyDataFrame {
             .df
             .as_ref()
             .clone()
-            .intersect(py_df.df.as_ref().clone())?;
+            .intersect(py_df.df.as_ref().clone())
+            .map_err(from_datafusion_error)?;
         Ok(Self::new(new_df))
     }
 
     /// Calculate the exception of two `DataFrame`s.  The two `DataFrame`s must have exactly the same schema
     fn except_all(&self, py_df: PyDataFrame) -> PyResult<Self> {
-        let new_df = self.df.as_ref().clone().except(py_df.df.as_ref().clone())?;
+        let new_df = self
+            .df
+            .as_ref()
+            .clone()
+            .except(py_df.df.as_ref().clone())
+            .map_err(from_datafusion_error)?;
         Ok(Self::new(new_df))
     }
 
@@ -324,7 +373,7 @@ impl PyDataFrame {
 
     fn execute_stream(&self, py: Python) -> PyResult<PyRecordBatchStream> {
         // create a Tokio runtime to run the async code
-        let rt = &get_tokio_runtime(py).0;
+        let rt = &get_tokio_runtime();
         let df = self.df.as_ref().clone();
 
         let fut: JoinHandle<PyResult<SendableRecordBatchStream>> =
@@ -335,7 +384,7 @@ impl PyDataFrame {
 
     fn execute_stream_partitioned(&self, py: Python) -> PyResult<Vec<PyRecordBatchStream>> {
         // create a Tokio runtime to run the async code
-        let rt = &get_tokio_runtime(py).0;
+        let rt = &get_tokio_runtime();
         let df = self.df.as_ref().clone();
         let fut: JoinHandle<datafusion_common::Result<Vec<SendableRecordBatchStream>>> =
             rt.spawn(async move { df.execute_stream_partitioned().await });
@@ -398,7 +447,7 @@ impl PyDataFrame {
 
     // Executes this DataFrame to get the total number of rows.
     fn count(&self, py: Python) -> PyResult<usize> {
-        Ok(wait_for_future(py, self.df.as_ref().clone().count())?)
+        wait_for_future(py, self.df.as_ref().clone().count()).map_err(from_datafusion_error)
     }
 
     /// Get the execution plan for this `DataFrame`
@@ -412,7 +461,7 @@ impl PyDataFrame {
 /// Print DataFrame
 fn print_dataframe(py: Python, df: DataFrame) -> PyResult<()> {
     // Get string representation of record batches
-    let batches = wait_for_future(py, df.collect())?;
+    let batches = wait_for_future(py, df.collect()).map_err(from_datafusion_error)?;
     let batches_as_string = pretty::pretty_format_batches(&batches);
     let result = match batches_as_string {
         Ok(batch) => format!("DataFrame()\n{batch}"),

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -48,7 +48,7 @@ impl Dataset {
         // Ensure that we were passed an instance of pyarrow.dataset.Dataset
         let ds = PyModule::import(py, "pyarrow.dataset")?;
         let ds_attr = ds.getattr("Dataset")?;
-        let ds_type = ds_attr.downcast::<PyType>()?;
+        let ds_type = ds_attr.cast::<PyType>()?;
         if dataset.is_instance(ds_type)? {
             Ok(Dataset {
                 dataset: dataset.clone().unbind(),

--- a/src/dataset_exec.rs
+++ b/src/dataset_exec.rs
@@ -19,12 +19,11 @@ use datafusion::error::{DataFusionError as InnerDataFusionError, Result as DFRes
 use datafusion::execution::context::TaskContext;
 use datafusion::logical_expr::utils::conjunction;
 use datafusion::logical_expr::Expr;
-use datafusion::physical_expr::{EquivalenceProperties, LexOrdering};
+use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, Partitioning,
-    SendableRecordBatchStream, Statistics,
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, SendableRecordBatchStream,
 };
 
 struct PyArrowBatchesAdapter {
@@ -55,8 +54,7 @@ pub(crate) struct DatasetExec {
     fragments: Py<PyList>,
     columns: Option<Vec<String>>,
     filter_expr: Option<Py<PyAny>>,
-    projected_statistics: Statistics,
-    plan_properties: datafusion::physical_plan::PlanProperties,
+    plan_properties: Arc<datafusion::physical_plan::PlanProperties>,
 }
 
 impl DatasetExec {
@@ -96,7 +94,7 @@ impl DatasetExec {
 
         let scanner = dataset.call_method("scanner", (), Some(&kwargs))?;
 
-        let schema = Arc::new(
+        let schema: SchemaRef = Arc::new(
             scanner
                 .getattr("projected_schema")?
                 .extract::<PyArrowType<_>>()?
@@ -113,15 +111,14 @@ impl DatasetExec {
         )?;
 
         let fragments_iter = pylist.call1((fragments_iterator,))?;
-        let fragments = fragments_iter.downcast::<PyList>().map_err(PyErr::from)?;
+        let fragments = fragments_iter.cast::<PyList>().map_err(PyErr::from)?;
 
-        let projected_statistics = Statistics::new_unknown(&schema);
-        let plan_properties = datafusion::physical_plan::PlanProperties::new(
+        let plan_properties = Arc::new(datafusion::physical_plan::PlanProperties::new(
             EquivalenceProperties::new(schema.clone()),
             Partitioning::UnknownPartitioning(fragments.len()),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
 
         Ok(DatasetExec {
             dataset: dataset.clone().unbind(),
@@ -129,7 +126,6 @@ impl DatasetExec {
             fragments: fragments.clone().unbind(),
             columns,
             filter_expr,
-            projected_statistics,
             plan_properties,
         })
     }
@@ -151,7 +147,7 @@ impl ExecutionPlan for DatasetExec {
         self.schema.clone()
     }
 
-    fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
+    fn properties(&self) -> &Arc<datafusion::physical_plan::PlanProperties> {
         &self.plan_properties
     }
 
@@ -222,33 +218,6 @@ impl ExecutionPlan for DatasetExec {
             );
             Ok(record_batch_stream)
         })
-    }
-
-    fn statistics(&self) -> DFResult<Statistics> {
-        Ok(self.projected_statistics.clone())
-    }
-}
-
-impl ExecutionPlanProperties for DatasetExec {
-    /// Get the output partitioning of this plan
-    fn output_partitioning(&self) -> &Partitioning {
-        self.plan_properties.output_partitioning()
-    }
-
-    fn output_ordering(&self) -> Option<&LexOrdering> {
-        None
-    }
-
-    fn boundedness(&self) -> Boundedness {
-        self.plan_properties.boundedness
-    }
-
-    fn pipeline_behavior(&self) -> EmissionType {
-        self.plan_properties.emission_type
-    }
-
-    fn equivalence_properties(&self) -> &EquivalenceProperties {
-        &self.plan_properties.eq_properties
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -23,7 +23,6 @@ use datafusion::arrow::datatypes::{DataType, Field};
 use datafusion::arrow::pyarrow::PyArrowType;
 use datafusion::functions::core::expr_ext::FieldAccessor;
 use datafusion::logical_expr::expr::AggregateFunctionParams;
-use datafusion::scalar::ScalarValue;
 use datafusion_expr::{
     col,
     expr::{AggregateFunction, InList, InSubquery, ScalarFunction},
@@ -33,7 +32,7 @@ use datafusion_expr::{
 };
 use sort_expr::PySortExpr;
 
-use crate::common::data_type::{DataTypeMap, RexType};
+use crate::common::data_type::{DataTypeMap, PyScalarValue, RexType};
 use crate::errors::{py_runtime_err, py_type_err, DataFusionError};
 use crate::expr::aggregate_expr::PyAggregateFunction;
 use crate::expr::binary_expr::PyBinaryExpr;
@@ -99,7 +98,7 @@ mod wildcard;
 pub mod window;
 
 /// A PyExpr that can be used on a DataFrame
-#[pyclass(name = "Expr", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Expr", module = "datafusion.expr", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyExpr {
     pub expr: Expr,
@@ -129,8 +128,8 @@ impl PyExpr {
         Python::attach(|_| match &self.expr {
             Expr::Alias(alias) => Ok(PyAlias::new(&alias.expr, &alias.name).into_bound_py_any(py)?),
             Expr::Column(col) => Ok(PyColumn::from(col.clone()).into_bound_py_any(py)?),
-            Expr::ScalarVariable(data_type, variables) => {
-                Ok(PyScalarVariable::new(data_type, variables).into_bound_py_any(py)?)
+            Expr::ScalarVariable(field, variables) => {
+                Ok(PyScalarVariable::new(field.data_type(), variables).into_bound_py_any(py)?)
             }
             Expr::Like(value) => Ok(PyLike::from(value.clone()).into_bound_py_any(py)?),
             Expr::Literal(value, metadata) => Ok(PyLiteral::new_with_metadata(
@@ -239,8 +238,8 @@ impl PyExpr {
     }
 
     #[staticmethod]
-    pub fn literal(value: ScalarValue) -> PyExpr {
-        lit(value).into()
+    pub fn literal(value: PyScalarValue) -> PyExpr {
+        lit(value.0).into()
     }
 
     #[staticmethod]
@@ -304,7 +303,8 @@ impl PyExpr {
             | Expr::Placeholder { .. }
             | Expr::OuterReferenceColumn(_, _)
             | Expr::Unnest(_)
-            | Expr::IsNotUnknown(_) => RexType::Call,
+            | Expr::IsNotUnknown(_)
+            | Expr::SetComparison(_) => RexType::Call,
             Expr::ScalarSubquery(..) => RexType::ScalarSubquery,
             #[allow(deprecated)]
             Expr::Wildcard { .. } => RexType::Call,
@@ -437,7 +437,8 @@ impl PyExpr {
             | Expr::Wildcard { .. }
             | Expr::ScalarSubquery(..)
             | Expr::Placeholder { .. }
-            | Expr::Exists { .. } => Err(py_runtime_err(format!(
+            | Expr::Exists { .. }
+            | Expr::SetComparison(..) => Err(py_runtime_err(format!(
                 "Unimplemented Expr type: {}",
                 self.expr
             ))),
@@ -515,11 +516,10 @@ impl PyExpr {
             #[allow(deprecated)]
             Expr::Wildcard { .. } => {
                 // Since * could be any of the valid column names just return the first one
-                Ok(Arc::new(input_plan.schema().field(0).clone()))
+                Ok(input_plan.schema().field(0).clone())
             }
             _ => {
-                let fields =
-                    exprlist_to_fields(&[expr.clone()], input_plan).map_err(PyErr::from)?;
+                let fields = exprlist_to_fields(&[expr.clone()], input_plan)?;
                 Ok(fields[0].1.clone())
             }
         }
@@ -572,7 +572,8 @@ impl PyExpr {
                 | Operator::AtQuestion
                 | Operator::Question
                 | Operator::QuestionAnd
-                | Operator::QuestionPipe => Err(py_type_err(format!("Unsupported expr: ${op}"))),
+                | Operator::QuestionPipe
+                | Operator::Colon => Err(py_type_err(format!("Unsupported expr: ${op}"))),
             },
             Expr::Cast(Cast { expr: _, data_type }) => DataTypeMap::map_from_arrow_type(data_type),
             Expr::Literal(scalar_value, _) => DataTypeMap::map_from_scalar_value(scalar_value),

--- a/src/expr/aggregate.rs
+++ b/src/expr/aggregate.rs
@@ -28,7 +28,12 @@ use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "Aggregate", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "Aggregate",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyAggregate {
     aggregate: Aggregate,

--- a/src/expr/aggregate_expr.rs
+++ b/src/expr/aggregate_expr.rs
@@ -20,7 +20,12 @@ use datafusion_expr::expr::AggregateFunction;
 use pyo3::prelude::*;
 use std::fmt::{Display, Formatter};
 
-#[pyclass(name = "AggregateFunction", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "AggregateFunction",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyAggregateFunction {
     aggr: AggregateFunction,

--- a/src/expr/alias.rs
+++ b/src/expr/alias.rs
@@ -21,7 +21,7 @@ use std::fmt::{self, Display, Formatter};
 
 use datafusion_expr::Expr;
 
-#[pyclass(name = "Alias", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Alias", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyAlias {
     expr: PyExpr,

--- a/src/expr/analyze.rs
+++ b/src/expr/analyze.rs
@@ -24,7 +24,7 @@ use std::fmt::{self, Display, Formatter};
 
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(name = "Analyze", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Analyze", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyAnalyze {
     analyze: Analyze,

--- a/src/expr/between.rs
+++ b/src/expr/between.rs
@@ -20,7 +20,7 @@ use datafusion_expr::expr::Between;
 use pyo3::prelude::*;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "Between", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Between", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyBetween {
     between: Between,

--- a/src/expr/binary_expr.rs
+++ b/src/expr/binary_expr.rs
@@ -19,7 +19,12 @@ use crate::expr::PyExpr;
 use datafusion_expr::BinaryExpr;
 use pyo3::prelude::*;
 
-#[pyclass(name = "BinaryExpr", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "BinaryExpr",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyBinaryExpr {
     expr: BinaryExpr,

--- a/src/expr/bool_expr.rs
+++ b/src/expr/bool_expr.rs
@@ -21,7 +21,7 @@ use std::fmt::{self, Display, Formatter};
 
 use super::PyExpr;
 
-#[pyclass(name = "Not", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Not", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyNot {
     expr: Expr,
@@ -51,7 +51,12 @@ impl PyNot {
     }
 }
 
-#[pyclass(name = "IsNotNull", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "IsNotNull",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone, Debug)]
 pub struct PyIsNotNull {
     expr: Expr,
@@ -81,7 +86,7 @@ impl PyIsNotNull {
     }
 }
 
-#[pyclass(name = "IsNull", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "IsNull", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyIsNull {
     expr: Expr,
@@ -111,7 +116,7 @@ impl PyIsNull {
     }
 }
 
-#[pyclass(name = "IsTrue", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "IsTrue", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyIsTrue {
     expr: Expr,
@@ -141,7 +146,7 @@ impl PyIsTrue {
     }
 }
 
-#[pyclass(name = "IsFalse", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "IsFalse", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyIsFalse {
     expr: Expr,
@@ -171,7 +176,12 @@ impl PyIsFalse {
     }
 }
 
-#[pyclass(name = "IsUnknown", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "IsUnknown",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone, Debug)]
 pub struct PyIsUnknown {
     expr: Expr,
@@ -201,7 +211,12 @@ impl PyIsUnknown {
     }
 }
 
-#[pyclass(name = "IsNotTrue", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "IsNotTrue",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone, Debug)]
 pub struct PyIsNotTrue {
     expr: Expr,
@@ -231,7 +246,12 @@ impl PyIsNotTrue {
     }
 }
 
-#[pyclass(name = "IsNotFalse", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "IsNotFalse",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone, Debug)]
 pub struct PyIsNotFalse {
     expr: Expr,
@@ -261,7 +281,12 @@ impl PyIsNotFalse {
     }
 }
 
-#[pyclass(name = "IsNotUnknown", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "IsNotUnknown",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone, Debug)]
 pub struct PyIsNotUnknown {
     expr: Expr,
@@ -291,7 +316,12 @@ impl PyIsNotUnknown {
     }
 }
 
-#[pyclass(name = "Negative", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "Negative",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone, Debug)]
 pub struct PyNegative {
     expr: Expr,

--- a/src/expr/case.rs
+++ b/src/expr/case.rs
@@ -19,7 +19,7 @@ use crate::expr::PyExpr;
 use datafusion_expr::Case;
 use pyo3::prelude::*;
 
-#[pyclass(name = "Case", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Case", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCase {
     case: Case,

--- a/src/expr/cast.rs
+++ b/src/expr/cast.rs
@@ -19,7 +19,7 @@ use crate::{common::data_type::PyDataType, expr::PyExpr};
 use datafusion_expr::{Cast, TryCast};
 use pyo3::prelude::*;
 
-#[pyclass(name = "Cast", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Cast", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyCast {
     cast: Cast,
@@ -52,7 +52,7 @@ impl PyCast {
     }
 }
 
-#[pyclass(name = "TryCast", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "TryCast", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyTryCast {
     try_cast: TryCast,

--- a/src/expr/column.rs
+++ b/src/expr/column.rs
@@ -18,7 +18,7 @@
 use datafusion_common::Column;
 use pyo3::prelude::*;
 
-#[pyclass(name = "Column", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Column", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyColumn {
     pub col: Column,

--- a/src/expr/conditional_expr.rs
+++ b/src/expr/conditional_expr.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::errors::from_datafusion_error;
 use crate::expr::PyExpr;
 use datafusion_expr::conditional_expressions::CaseBuilder;
 use pyo3::prelude::*;
@@ -45,10 +46,20 @@ impl PyCaseBuilder {
     }
 
     fn otherwise(&mut self, else_expr: PyExpr) -> PyResult<PyExpr> {
-        Ok(self.case_builder.otherwise(else_expr.expr)?.clone().into())
+        Ok(self
+            .case_builder
+            .otherwise(else_expr.expr)
+            .map_err(from_datafusion_error)?
+            .clone()
+            .into())
     }
 
     fn end(&mut self) -> PyResult<PyExpr> {
-        Ok(self.case_builder.end()?.clone().into())
+        Ok(self
+            .case_builder
+            .end()
+            .map_err(from_datafusion_error)?
+            .clone()
+            .into())
     }
 }

--- a/src/expr/create_memory_table.rs
+++ b/src/expr/create_memory_table.rs
@@ -24,7 +24,12 @@ use pyo3::IntoPyObjectExt;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "CreateMemoryTable", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "CreateMemoryTable",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyCreateMemoryTable {
     create: CreateMemoryTable,

--- a/src/expr/create_view.rs
+++ b/src/expr/create_view.rs
@@ -24,7 +24,12 @@ use pyo3::IntoPyObjectExt;
 use super::logical_node::LogicalNode;
 use crate::{errors::py_type_err, sql::logical::PyLogicalPlan};
 
-#[pyclass(name = "CreateView", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "CreateView",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyCreateView {
     create: CreateView,

--- a/src/expr/distinct.rs
+++ b/src/expr/distinct.rs
@@ -24,7 +24,12 @@ use pyo3::IntoPyObjectExt;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "Distinct", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "Distinct",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyDistinct {
     distinct: Distinct,

--- a/src/expr/drop_table.rs
+++ b/src/expr/drop_table.rs
@@ -24,7 +24,12 @@ use pyo3::IntoPyObjectExt;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "DropTable", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "DropTable",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyDropTable {
     drop: DropTable,

--- a/src/expr/empty_relation.rs
+++ b/src/expr/empty_relation.rs
@@ -24,7 +24,12 @@ use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "EmptyRelation", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "EmptyRelation",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyEmptyRelation {
     empty: EmptyRelation,

--- a/src/expr/exists.rs
+++ b/src/expr/exists.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 
 use super::subquery::PySubquery;
 
-#[pyclass(name = "Exists", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Exists", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyExists {
     subquery: Subquery,

--- a/src/expr/explain.rs
+++ b/src/expr/explain.rs
@@ -24,7 +24,7 @@ use pyo3::IntoPyObjectExt;
 use super::logical_node::LogicalNode;
 use crate::{common::df_schema::PyDFSchema, errors::py_type_err, sql::logical::PyLogicalPlan};
 
-#[pyclass(name = "Explain", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Explain", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyExplain {
     explain: Explain,

--- a/src/expr/extension.rs
+++ b/src/expr/extension.rs
@@ -22,7 +22,12 @@ use pyo3::IntoPyObjectExt;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "Extension", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "Extension",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyExtension {
     pub node: Extension,

--- a/src/expr/filter.rs
+++ b/src/expr/filter.rs
@@ -24,7 +24,7 @@ use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "Filter", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Filter", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyFilter {
     filter: Filter,

--- a/src/expr/grouping_set.rs
+++ b/src/expr/grouping_set.rs
@@ -18,7 +18,12 @@
 use datafusion_expr::GroupingSet;
 use pyo3::prelude::*;
 
-#[pyclass(name = "GroupingSet", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "GroupingSet",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyGroupingSet {
     grouping_set: GroupingSet,

--- a/src/expr/in_list.rs
+++ b/src/expr/in_list.rs
@@ -19,7 +19,7 @@ use crate::expr::PyExpr;
 use datafusion_expr::Expr;
 use pyo3::prelude::*;
 
-#[pyclass(name = "InList", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "InList", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyInList {
     expr: Box<Expr>,

--- a/src/expr/in_subquery.rs
+++ b/src/expr/in_subquery.rs
@@ -20,7 +20,12 @@ use pyo3::prelude::*;
 
 use super::{subquery::PySubquery, PyExpr};
 
-#[pyclass(name = "InSubquery", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "InSubquery",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyInSubquery {
     expr: Box<Expr>,

--- a/src/expr/join.rs
+++ b/src/expr/join.rs
@@ -28,7 +28,7 @@ use crate::expr::PyExpr;
 use crate::sql::logical::PyLogicalPlan;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[pyclass(frozen, name = "JoinType", module = "datafusion.expr")]
+#[pyclass(from_py_object, frozen, name = "JoinType", module = "datafusion.expr")]
 pub struct PyJoinType {
     join_type: JoinType,
 }
@@ -63,7 +63,12 @@ impl Display for PyJoinType {
 }
 
 #[derive(Debug, Clone, Copy)]
-#[pyclass(frozen, name = "JoinConstraint", module = "datafusion.expr")]
+#[pyclass(
+    from_py_object,
+    frozen,
+    name = "JoinConstraint",
+    module = "datafusion.expr"
+)]
 pub struct PyJoinConstraint {
     join_constraint: JoinConstraint,
 }
@@ -90,7 +95,13 @@ impl PyJoinConstraint {
     }
 }
 
-#[pyclass(frozen, name = "Join", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    frozen,
+    name = "Join",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyJoin {
     join: Join,

--- a/src/expr/like.rs
+++ b/src/expr/like.rs
@@ -21,7 +21,7 @@ use std::fmt::{self, Display, Formatter};
 
 use crate::expr::PyExpr;
 
-#[pyclass(name = "Like", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Like", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyLike {
     like: Like,
@@ -79,7 +79,7 @@ impl PyLike {
     }
 }
 
-#[pyclass(name = "ILike", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "ILike", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyILike {
     like: Like,
@@ -137,7 +137,12 @@ impl PyILike {
     }
 }
 
-#[pyclass(name = "SimilarTo", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "SimilarTo",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PySimilarTo {
     like: Like,

--- a/src/expr/limit.rs
+++ b/src/expr/limit.rs
@@ -25,7 +25,7 @@ use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "Limit", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Limit", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyLimit {
     limit: Limit,

--- a/src/expr/literal.rs
+++ b/src/expr/literal.rs
@@ -15,12 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::errors::to_external_err;
 use datafusion::{common::ScalarValue, logical_expr::expr::FieldMetadata};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
-#[pyclass(name = "Literal", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Literal", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyLiteral {
     pub value: ScalarValue,
@@ -156,12 +155,7 @@ impl PyLiteral {
 
     #[allow(clippy::wrong_self_convention)]
     fn into_type(&self, py: Python) -> PyResult<Py<PyAny>> {
-        Ok(self
-            .clone()
-            .into_pyobject(py)
-            .map_err(to_external_err)?
-            .into_any()
-            .unbind())
+        Ok(self.clone().into_pyobject(py)?.into_any().unbind())
     }
 
     fn __repr__(&self) -> PyResult<String> {

--- a/src/expr/ordered.rs
+++ b/src/expr/ordered.rs
@@ -4,7 +4,7 @@ use std::clone::Clone;
 
 use crate::expr::PyExpr;
 
-#[pyclass(name = "Ordered", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Ordered", module = "datafusion.expr", subclass)]
 #[derive(Clone, Debug)]
 pub struct PyOrdered {
     pub expr: PyExpr,

--- a/src/expr/placeholder.rs
+++ b/src/expr/placeholder.rs
@@ -20,7 +20,12 @@ use pyo3::prelude::*;
 
 use crate::common::data_type::PyDataType;
 
-#[pyclass(name = "Placeholder", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "Placeholder",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyPlaceholder {
     id: String,

--- a/src/expr/projection.rs
+++ b/src/expr/projection.rs
@@ -25,7 +25,12 @@ use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "Projection", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "Projection",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyProjection {
     pub projection: Projection,

--- a/src/expr/repartition.rs
+++ b/src/expr/repartition.rs
@@ -24,13 +24,23 @@ use pyo3::IntoPyObjectExt;
 use super::{logical_node::LogicalNode, PyExpr};
 use crate::{errors::py_type_err, sql::logical::PyLogicalPlan};
 
-#[pyclass(name = "Repartition", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "Repartition",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyRepartition {
     repartition: Repartition,
 }
 
-#[pyclass(name = "Partitioning", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "Partitioning",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyPartitioning {
     partitioning: Partitioning,

--- a/src/expr/scalar_subquery.rs
+++ b/src/expr/scalar_subquery.rs
@@ -20,7 +20,12 @@ use pyo3::prelude::*;
 
 use super::subquery::PySubquery;
 
-#[pyclass(name = "ScalarSubquery", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "ScalarSubquery",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyScalarSubquery {
     subquery: Subquery,

--- a/src/expr/scalar_variable.rs
+++ b/src/expr/scalar_variable.rs
@@ -20,7 +20,12 @@ use pyo3::prelude::*;
 
 use crate::common::data_type::PyDataType;
 
-#[pyclass(name = "ScalarVariable", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "ScalarVariable",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyScalarVariable {
     data_type: DataType,

--- a/src/expr/signature.rs
+++ b/src/expr/signature.rs
@@ -19,7 +19,12 @@ use datafusion_expr::{TypeSignature, Volatility};
 use pyo3::prelude::*;
 
 #[allow(dead_code)]
-#[pyclass(name = "Signature", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "Signature",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PySignature {
     type_signature: TypeSignature,

--- a/src/expr/sort.rs
+++ b/src/expr/sort.rs
@@ -25,7 +25,7 @@ use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "Sort", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Sort", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySort {
     sort: Sort,

--- a/src/expr/sort_expr.rs
+++ b/src/expr/sort_expr.rs
@@ -20,7 +20,12 @@ use datafusion::logical_expr::SortExpr;
 use pyo3::prelude::*;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "SortExpr", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "SortExpr",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PySortExpr {
     pub sort: SortExpr,

--- a/src/expr/subquery.rs
+++ b/src/expr/subquery.rs
@@ -24,7 +24,12 @@ use pyo3::IntoPyObjectExt;
 
 use super::logical_node::LogicalNode;
 
-#[pyclass(name = "Subquery", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "Subquery",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PySubquery {
     subquery: Subquery,

--- a/src/expr/subquery_alias.rs
+++ b/src/expr/subquery_alias.rs
@@ -24,7 +24,12 @@ use pyo3::IntoPyObjectExt;
 use super::logical_node::LogicalNode;
 use crate::{common::df_schema::PyDFSchema, sql::logical::PyLogicalPlan};
 
-#[pyclass(name = "SubqueryAlias", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "SubqueryAlias",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PySubqueryAlias {
     subquery_alias: SubqueryAlias,

--- a/src/expr/table_scan.rs
+++ b/src/expr/table_scan.rs
@@ -24,7 +24,12 @@ use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "TableScan", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "TableScan",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyTableScan {
     table_scan: TableScan,

--- a/src/expr/union.rs
+++ b/src/expr/union.rs
@@ -23,7 +23,7 @@ use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use std::fmt::{self, Display, Formatter};
 
-#[pyclass(name = "Union", module = "datafusion.expr", subclass)]
+#[pyclass(from_py_object, name = "Union", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PyUnion {
     union_: Union,

--- a/src/expr/wildcard.rs
+++ b/src/expr/wildcard.rs
@@ -1,7 +1,12 @@
 use datafusion_common::TableReference;
 use pyo3::{pyclass, pymethods, PyResult};
 
-#[pyclass(name = "Wildcard", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "Wildcard",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyWildcard {
     qualifier: Option<String>,

--- a/src/expr/window.rs
+++ b/src/expr/window.rs
@@ -31,13 +31,25 @@ use crate::expr::sort_expr::{py_sort_expr_list, PySortExpr};
 use crate::expr::PyExpr;
 use crate::sql::logical::PyLogicalPlan;
 
-#[pyclass(frozen, name = "WindowExpr", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    frozen,
+    name = "WindowExpr",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyWindow {
     window: Window,
 }
 
-#[pyclass(frozen, name = "WindowFrame", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    frozen,
+    name = "WindowFrame",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyWindowFrame {
     window_frame: WindowFrame,
@@ -55,7 +67,12 @@ impl From<WindowFrame> for PyWindowFrame {
     }
 }
 
-#[pyclass(name = "WindowFrameBound", module = "datafusion.expr", subclass)]
+#[pyclass(
+    from_py_object,
+    name = "WindowFrameBound",
+    module = "datafusion.expr",
+    subclass
+)]
 #[derive(Clone)]
 pub struct PyWindowFrameBound {
     frame_bound: WindowFrameBound,

--- a/src/ibis_table.rs
+++ b/src/ibis_table.rs
@@ -31,7 +31,7 @@ impl IbisTable {
     pub fn new(ibis_table: &Bound<'_, PyAny>, py: Python) -> PyResult<Self> {
         let pa = PyModule::import(py, "ibis.expr.types")?;
         let table = pa.getattr("Table")?;
-        let table_type = table.downcast::<PyType>()?;
+        let table_type = table.cast::<PyType>()?;
 
         if ibis_table.is_instance(table_type)? {
             Ok(IbisTable {

--- a/src/ibis_table_exec.rs
+++ b/src/ibis_table_exec.rs
@@ -72,7 +72,7 @@ pub struct IbisTableExec {
     record_batch_reader: Py<PyAny>,
     schema: SchemaRef,
     columns: Option<Vec<String>>,
-    cache: PlanProperties,
+    cache: Arc<PlanProperties>,
 }
 
 impl IbisTableExec {
@@ -134,7 +134,7 @@ impl ExecutionPlan for IbisTableExec {
         self.schema.clone()
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.cache
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,18 +32,10 @@ pub mod utils;
 
 mod object_storage;
 
-// Used to define Tokio Runtime as a Python module attribute
-#[pyclass]
-pub(crate) struct TokioRuntime(tokio::runtime::Runtime);
-
 /// Low-level xorq internal package.
 #[pymodule]
 fn _internal(py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     // Register the Tokio Runtime as a module attribute, so we can reuse it
-    m.add(
-        "runtime",
-        TokioRuntime(tokio::runtime::Runtime::new().unwrap()),
-    )?;
 
     m.add_class::<context::PySessionConfig>()?;
     m.add_class::<context::PySessionContext>()?;

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -12,7 +12,7 @@ use pyo3::prelude::PyModule;
 use pyo3::prelude::*;
 use pyo3::{pyclass, pyfunction, pymethods, wrap_pyfunction, PyResult, Python};
 
-#[pyclass(name = "Optimizer", module = "let", subclass)]
+#[pyclass(from_py_object, name = "Optimizer", module = "let", subclass)]
 #[derive(Clone, Default)]
 pub struct PyOptimizer {
     pub optimizer: Arc<Optimizer>,
@@ -82,7 +82,7 @@ impl OptimizerRule for PyOptimizerRule {
     }
 }
 
-#[pyclass(name = "OptimizerContext", module = "let", subclass)]
+#[pyclass(from_py_object, name = "OptimizerContext", module = "let", subclass)]
 #[derive(Clone, Default)]
 pub struct PyOptimizerContext {
     pub(crate) context: Arc<OptimizerContext>,

--- a/src/physical_plan.rs
+++ b/src/physical_plan.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use pyo3::prelude::*;
 
-#[pyclass(name = "ExecutionPlan", module = "let", subclass)]
+#[pyclass(from_py_object, name = "ExecutionPlan", module = "let", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyExecutionPlan {
     pub plan: Arc<dyn ExecutionPlan>,

--- a/src/py_record_batch_provider.rs
+++ b/src/py_record_batch_provider.rs
@@ -1,14 +1,12 @@
 use std::any::Any;
-use std::ops::DerefMut;
-use std::pin::Pin;
-use std::sync::{Arc, Mutex};
-use std::{fmt, thread};
+use std::fmt;
+use std::sync::Arc;
 
 use crate::utils::compute_properties_with_orderings;
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::ffi_stream::ArrowArrayStreamReader;
-use datafusion::arrow::record_batch::{RecordBatch, RecordBatchReader};
+use datafusion::arrow::pyarrow::PyArrowType;
 use datafusion::catalog::Session;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::Result;
@@ -21,17 +19,32 @@ use datafusion::physical_plan::{
 };
 use datafusion_common::DataFusionError;
 use datafusion_expr::Expr;
-use futures::stream::Stream;
-use futures::task::{Context, Poll};
+use pyo3::prelude::*;
 
+/// A [`TableProvider`] backed by a Python object that supports the Arrow C stream
+/// interface (`__arrow_c_stream__`).
+///
+/// The Python object is held by reference and re-queried on every `execute()` call,
+/// so tables that support multiple calls to `__arrow_c_stream__` (e.g. `pyarrow.Table`)
+/// can be scanned more than once.  Single-use readers (e.g. `pyarrow.RecordBatchReader`)
+/// will raise a Python error on the second call, which surfaces as a `DataFusionError`
+/// rather than silently returning empty results.
 #[derive(Clone, Debug)]
 pub struct PyRecordBatchProvider {
-    reader: Arc<Mutex<Option<ArrowArrayStreamReader>>>,
+    py_object: Arc<Py<PyAny>>,
     schema: SchemaRef,
     ordering: Option<LexOrdering>,
 }
 
 impl PyRecordBatchProvider {
+    pub fn new(py_object: Py<PyAny>, schema: SchemaRef, ordering: Option<LexOrdering>) -> Self {
+        Self {
+            py_object: Arc::new(py_object),
+            schema,
+            ordering,
+        }
+    }
+
     pub(crate) async fn create_physical_plan(
         &self,
         projections: Option<&Vec<usize>>,
@@ -42,15 +55,6 @@ impl PyRecordBatchProvider {
             projections,
             schema,
         )))
-    }
-
-    pub fn new(aasr: ArrowArrayStreamReader, ordering: Option<LexOrdering>) -> Self {
-        let schema = aasr.schema();
-        Self {
-            reader: Arc::new(Mutex::new(aasr.into())),
-            schema,
-            ordering,
-        }
     }
 }
 
@@ -79,84 +83,12 @@ impl TableProvider for PyRecordBatchProvider {
     }
 }
 
-impl Stream for PyRecordBatchProvider {
-    type Item = Result<RecordBatch>;
-
-    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match self.reader.lock().unwrap().deref_mut() {
-            Some(ref mut reader) => thread::scope(|s| {
-                let res = s
-                    .spawn(move || match reader.next() {
-                        Some(value) => Poll::Ready(Some(value)).map_err(DataFusionError::from),
-                        None => Poll::Ready(None),
-                    })
-                    .join();
-
-                match res {
-                    Ok(val) => val,
-                    _ => Poll::Ready(None),
-                }
-            }),
-            _ => Poll::Ready(None),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct ProjectedPyRecordBatchProvider {
-    record_batch_provider: PyRecordBatchProvider,
-    projections: Vec<usize>,
-}
-
-impl ProjectedPyRecordBatchProvider {
-    fn new(record_batch_provider: PyRecordBatchProvider, projections: Vec<usize>) -> Self {
-        let projections = projections.clone();
-        Self {
-            record_batch_provider,
-            projections,
-        }
-    }
-}
-
-impl Stream for ProjectedPyRecordBatchProvider {
-    type Item = Result<RecordBatch>;
-
-    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let projections = self.projections.clone();
-        match self
-            .record_batch_provider
-            .reader
-            .lock()
-            .unwrap()
-            .deref_mut()
-        {
-            Some(ref mut reader) => thread::scope(|s| {
-                let res = s
-                    .spawn(move || match reader.next() {
-                        Some(value) => Poll::Ready(Some(
-                            value.map(|rb| rb.project(projections.as_slice()).unwrap()),
-                        ))
-                        .map_err(DataFusionError::from),
-                        None => Poll::Ready(None),
-                    })
-                    .join();
-
-                match res {
-                    Ok(val) => val,
-                    _ => Poll::Ready(None),
-                }
-            }),
-            _ => Poll::Ready(None),
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 struct PyRecordBatchProviderExec {
     record_batch_provider: PyRecordBatchProvider,
     projected_schema: SchemaRef,
     projections: Option<Vec<usize>>,
-    plan_properties: PlanProperties,
+    plan_properties: Arc<PlanProperties>,
 }
 
 impl PyRecordBatchProviderExec {
@@ -206,7 +138,7 @@ impl ExecutionPlan for PyRecordBatchProviderExec {
         self.projected_schema.clone()
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.plan_properties
     }
 
@@ -225,28 +157,66 @@ impl ExecutionPlan for PyRecordBatchProviderExec {
         Ok(self)
     }
 
+    /// Acquire a fresh stream from Python and return it as a lazy async stream.
+    ///
+    /// Each batch is fetched inside `spawn_blocking` so that the Arrow C-callback
+    /// invocations (which may need the GIL) never block the Tokio executor thread.
+    /// Only one batch is in flight at a time; the full dataset is never materialised.
     fn execute(
         &self,
         _partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let record_batch_provider = self.record_batch_provider.clone();
         let projections = self.projections.clone();
         let projected_schema = self.projected_schema.clone();
 
-        let record_batch_stream: SendableRecordBatchStream = if let Some(pj) = projections {
-            let record_batch_provider =
-                ProjectedPyRecordBatchProvider::new(record_batch_provider.clone(), pj.clone());
-            Box::pin(RecordBatchStreamAdapter::new(
-                projected_schema.clone(),
-                record_batch_provider,
-            ))
-        } else {
-            Box::pin(RecordBatchStreamAdapter::new(
-                projected_schema.clone(),
-                record_batch_provider,
-            ))
-        };
-        Ok(record_batch_stream)
+        let reader = Python::attach(|py| {
+            self.record_batch_provider
+                .py_object
+                .bind(py)
+                .extract::<PyArrowType<ArrowArrayStreamReader>>()
+                .map(|t| t.0)
+                .map_err(|e| DataFusionError::External(Box::new(e)))
+        })?;
+
+        // Drive the sync reader one batch at a time from a blocking thread so we
+        // never stall the async executor.  The reader is moved into the unfold state
+        // and is held for the lifetime of the stream.
+        let stream = futures::stream::unfold(Some(reader), move |state| {
+            let projections = projections.clone();
+            async move {
+                let mut reader = state?;
+                let result = tokio::task::spawn_blocking(move || {
+                    // Acquire the GIL for each batch: the C callbacks registered by
+                    // PyArrow may call back into Python for non-in-memory sources.
+                    let batch = Python::attach(|_py| reader.next());
+                    (batch, reader)
+                })
+                .await;
+
+                match result {
+                    Ok((None, _)) => None,
+                    Ok((Some(batch_result), reader)) => {
+                        let item = batch_result.map_err(DataFusionError::from).and_then(|rb| {
+                            match &projections {
+                                Some(pj) => {
+                                    rb.project(pj.as_slice()).map_err(DataFusionError::from)
+                                }
+                                None => Ok(rb),
+                            }
+                        });
+                        Some((item, Some(reader)))
+                    }
+                    Err(join_err) => {
+                        Some((Err(DataFusionError::External(Box::new(join_err))), None))
+                    }
+                }
+            }
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            projected_schema,
+            stream,
+        )))
     }
 }

--- a/src/pyarrow_util.rs
+++ b/src/pyarrow_util.rs
@@ -21,7 +21,7 @@ use arrow::array::{Array, ArrayData};
 use arrow::pyarrow::{FromPyArrow, ToPyArrow};
 use datafusion::scalar::ScalarValue;
 use pyo3::types::{PyAnyMethods, PyList};
-use pyo3::{Bound, FromPyObject, PyAny, PyResult, Python};
+use pyo3::{Borrowed, Bound, FromPyObject, PyAny, PyErr, PyResult, Python};
 
 use crate::common::data_type::PyScalarValue;
 use crate::errors::DataFusionError;
@@ -45,9 +45,11 @@ impl FromPyArrow for PyScalarValue {
     }
 }
 
-impl<'source> FromPyObject<'source> for PyScalarValue {
-    fn extract_bound(value: &Bound<'source, PyAny>) -> PyResult<Self> {
-        Self::from_pyarrow_bound(value)
+impl<'a, 'py> FromPyObject<'a, 'py> for PyScalarValue {
+    type Error = PyErr;
+
+    fn extract(value: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
+        Self::from_pyarrow_bound(&value)
     }
 }
 

--- a/src/sql/builder.rs
+++ b/src/sql/builder.rs
@@ -8,7 +8,7 @@ use datafusion_expr::{table_scan, Expr, LogicalPlanBuilder, SortExpr};
 
 use pyo3::prelude::*;
 
-#[pyclass(name = "LogicalPlanBuilder", module = "let", subclass)]
+#[pyclass(from_py_object, name = "LogicalPlanBuilder", module = "let", subclass)]
 #[derive(Clone)]
 pub struct PyLogicalPlanBuilder {
     builder: LogicalPlanBuilder,

--- a/src/sql/logical.rs
+++ b/src/sql/logical.rs
@@ -38,7 +38,7 @@ use pyo3::prelude::*;
 
 use crate::expr::logical_node::LogicalNode;
 
-#[pyclass(name = "LogicalPlan", module = "let", subclass)]
+#[pyclass(from_py_object, name = "LogicalPlan", module = "let", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyLogicalPlan {
     pub(crate) plan: Arc<LogicalPlan>,

--- a/src/sql/parser.rs
+++ b/src/sql/parser.rs
@@ -24,7 +24,7 @@ fn create_table_source(fields: Vec<Field>) -> Arc<dyn TableSource> {
     )))
 }
 
-#[pyclass(name = "ContextProvider", module = "let", subclass)]
+#[pyclass(from_py_object, name = "ContextProvider", module = "let", subclass)]
 #[derive(Clone, Default)]
 pub struct PyContextProvider {
     options: ConfigOptions,

--- a/src/udaf.rs
+++ b/src/udaf.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use pyo3::{prelude::*, types::PyTuple};
 
+use crate::common::data_type::PyScalarValue;
 use crate::errors::to_external_err;
 use crate::expr::PyExpr;
 use crate::utils::parse_volatility;
@@ -44,8 +45,11 @@ impl Accumulator for RustAccumulator {
     }
 
     fn evaluate(&mut self) -> Result<ScalarValue> {
-        Python::attach(|py| self.accum.bind(py).call_method0("evaluate")?.extract())
-            .map_err(to_external_err)
+        Python::attach(|py| {
+            let result = self.accum.bind(py).call_method0("evaluate")?;
+            result.extract::<PyScalarValue>().map(|sv| sv.0)
+        })
+        .map_err(to_external_err)
     }
 
     fn size(&self) -> usize {
@@ -53,8 +57,13 @@ impl Accumulator for RustAccumulator {
     }
 
     fn state(&mut self) -> Result<Vec<ScalarValue>> {
-        Python::attach(|py| self.accum.bind(py).call_method0("state")?.extract())
-            .map_err(to_external_err)
+        Python::attach(|py| {
+            let result = self.accum.bind(py).call_method0("state")?;
+            result
+                .extract::<Vec<PyScalarValue>>()
+                .map(|v| v.into_iter().map(|sv| sv.0).collect())
+        })
+        .map_err(to_external_err)
     }
 
     fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
@@ -111,7 +120,7 @@ pub fn to_rust_accumulator(accum: Py<PyAny>) -> AccumulatorFactoryFunction {
 }
 
 /// Represents an AggregateUDF
-#[pyclass(name = "AggregateUDF", module = "let", subclass)]
+#[pyclass(from_py_object, name = "AggregateUDF", module = "let", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyAggregateUDF {
     pub(crate) function: AggregateUDF,

--- a/src/udf.rs
+++ b/src/udf.rs
@@ -36,7 +36,7 @@ fn to_rust_function(func: Py<PyAny>) -> ScalarFunctionImplementation {
 }
 
 /// Represents a PyScalarUDF
-#[pyclass(name = "ScalarUDF", module = "let", subclass)]
+#[pyclass(from_py_object, name = "ScalarUDF", module = "let", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyScalarUDF {
     pub(crate) function: ScalarUDF,

--- a/src/udwf.rs
+++ b/src/udwf.rs
@@ -204,7 +204,7 @@ pub fn to_rust_partition_evaluator(evaluator: Py<PyAny>) -> PartitionEvaluatorFa
 }
 
 /// Represents an WindowUDF
-#[pyclass(name = "WindowUDF", module = "let", subclass)]
+#[pyclass(from_py_object, name = "WindowUDF", module = "let", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyWindowUDF {
     pub(crate) function: WindowUDF,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use arrow::array::ArrayRef;
 use arrow::datatypes::SchemaRef;
@@ -13,12 +13,16 @@ use pyo3::prelude::*;
 use tokio::runtime::Runtime;
 
 use crate::errors::DataFusionError;
-use crate::TokioRuntime;
 
 /// Utility to get the Tokio Runtime from Python
-pub(crate) fn get_tokio_runtime(py: Python) -> PyRef<TokioRuntime> {
-    let datafusion = py.import("xorq_datafusion._internal").unwrap();
-    datafusion.getattr("runtime").unwrap().extract().unwrap()
+pub fn get_tokio_runtime() -> &'static Runtime {
+    // NOTE: Other pyo3 Python libraries have had issues with using tokio
+    // behind a forking app-server like `gunicorn`
+    // If we run into that problem, in the future we can look to `delta-rs`
+    // which adds a check in that disallows calls from a forked process
+    // https://github.com/delta-io/delta-rs/blob/87010461cfe01563d91a4b9cd6fa468e2ad5f283/python/src/utils.rs#L10-L31
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| Runtime::new().unwrap())
 }
 
 /// Utility to collect rust futures with GIL released
@@ -27,7 +31,7 @@ where
     F: Send + Future,
     F::Output: Send,
 {
-    let runtime: &Runtime = &get_tokio_runtime(py).0;
+    let runtime: &Runtime = get_tokio_runtime();
     py.detach(|| runtime.block_on(f))
 }
 #[allow(clippy::redundant_async_block)]
@@ -53,33 +57,33 @@ pub(crate) fn parse_volatility(value: &str) -> Result<Volatility, DataFusionErro
     })
 }
 
-pub fn compute_properties(schema: SchemaRef) -> PlanProperties {
+pub fn compute_properties(schema: SchemaRef) -> Arc<PlanProperties> {
     let eq_properties = EquivalenceProperties::new(schema);
 
-    PlanProperties::new(
+    Arc::new(PlanProperties::new(
         eq_properties,
         Partitioning::UnknownPartitioning(1),
         EmissionType::Incremental,
         Boundedness::Bounded,
-    )
+    ))
 }
 
 pub fn compute_properties_with_orderings(
     schema: SchemaRef,
     orderings: &[LexOrdering],
-) -> PlanProperties {
+) -> Arc<PlanProperties> {
     let eq_properties = if orderings.is_empty() {
         EquivalenceProperties::new(Arc::clone(&schema))
     } else {
         EquivalenceProperties::new_with_orderings(Arc::clone(&schema), orderings.to_vec())
     };
 
-    PlanProperties::new(
+    Arc::new(PlanProperties::new(
         eq_properties,
         Partitioning::UnknownPartitioning(1),
         EmissionType::Incremental,
         Boundedness::Bounded,
-    )
+    ))
 }
 
 pub fn make_scalar_function<F>(inner: F) -> ScalarFunctionImplementation


### PR DESCRIPTION
Update all DataFusion crates to v53, pyo3/pyo3-async-runtimes to 0.28,
arrow to v58 (pyarrow feature moved here from datafusion), tokio to 1.50.

- Remove pyarrow feature from datafusion dep (now on arrow crate)
- Fix pyo3 deprecation warnings across all bindings
- Adapt DataFusion v53 API changes (68 files)
- Add PyRecordBatchProvider replay/laziness tests
- Bump crate version to 0.2.6