### PR TITLE
build: add release profile optimizations to reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,8 @@ aws-config = "=0.101.0"
 aws-credential-types = "=0.101.0"
 object_store = { version = "0.13.1", features = ["aws", "gcp", "http"] }
 url = "2.5.7"
+
+[profile.release]
+lto = "thin"
+codegen-units = 2
+strip = true


### PR DESCRIPTION
Add LTO (thin), reduce codegen-units to 2, and enable symbol stripping to produce smaller wheel artifacts.